### PR TITLE
Skip non-directory files in dataset creation (like .gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+*.pickle
+ 
+# Byte-compiled / optimized / DLL files
+__pycache__/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# Environments
+.env
+.venv
+env/
+venv/

--- a/create_dataset.py
+++ b/create_dataset.py
@@ -3,21 +3,25 @@ import pickle
 
 import mediapipe as mp
 import cv2
-import matplotlib.pyplot as plt
 
 
 mp_hands = mp.solutions.hands
 mp_drawing = mp.solutions.drawing_utils
 mp_drawing_styles = mp.solutions.drawing_styles
 
-hands = mp_hands.Hands(static_image_mode=True, min_detection_confidence=0.3)
+hands = mp_hands.Hands(static_image_mode=True, min_detection_confidence=0.3, max_num_hands=1)
 
 DATA_DIR = './data'
 
 data = []
 labels = []
 for dir_ in os.listdir(DATA_DIR):
+    # skip files (like .gitignore)
+    if not os.path.isdir(os.path.join(DATA_DIR, dir_)):
+        continue
+    
     for img_path in os.listdir(os.path.join(DATA_DIR, dir_)):
+        print(f'Processing {dir_}/{img_path}...')
         data_aux = []
 
         x_ = []
@@ -48,3 +52,4 @@ for dir_ in os.listdir(DATA_DIR):
 f = open('data.pickle', 'wb')
 pickle.dump({'data': data, 'labels': labels}, f)
 f.close()
+print('Data saved to data.pickle')

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,2 +1,2 @@
-.gitignore
-
+!.gitignore
+*


### PR DESCRIPTION
I propose some minor modifications (which do not affect compatibility with the video tutorial) and avoid a bug during serialization.
- Add **max_num_hands** parameter to Hands class (set to 1), avoiding erroneous detection of a second hand (this sometimes occurs when the face appears in the frame during sampling).
- _(Bug Fix)_ Skip non-directory files that may be present under **./data** folder during dataset creation (like ._gitignore_)
- Display some status messages during serialization (the system seems frozen when many classes are processed).
- Added **.gitignore** to exclude the generated pickle file and **.venv** & IDE cache directories.